### PR TITLE
Label the release pages as 'stable', not 'latest'

### DIFF
--- a/main-site/src/pages/commandbook.tsx
+++ b/main-site/src/pages/commandbook.tsx
@@ -189,7 +189,7 @@ const CommandBookPage = ({ data }: { data: CommandBookPageData }) => {
                                         'http://dev.bukkit.org/bukkit-plugins/commandbook/files/'
                                     }
                                 >
-                                    Latest release for Bukkit
+                                    Stable builds for Bukkit
                                 </BlueOutboundButton>
                             </p>
                             <p>

--- a/main-site/src/pages/craftbook.tsx
+++ b/main-site/src/pages/craftbook.tsx
@@ -218,7 +218,7 @@ const CraftBookPage = ({ data }: { data: CraftBookPageData }) => {
                                         'http://dev.bukkit.org/bukkit-plugins/craftbook/files/'
                                     }
                                 >
-                                    Latest release for Bukkit
+                                    Stable builds for Bukkit
                                 </BlueOutboundButton>
                             </p>
                             <p>
@@ -270,7 +270,7 @@ const CraftBookPage = ({ data }: { data: CraftBookPageData }) => {
                                         'https://ore.spongepowered.org/EngineHub/CraftBook'
                                     }
                                 >
-                                    Latest release for Sponge
+                                    Stable builds for Sponge
                                 </BlueOutboundButton>
                             </p>
                             <p>

--- a/main-site/src/pages/worldedit.tsx
+++ b/main-site/src/pages/worldedit.tsx
@@ -215,7 +215,7 @@ const WorldEditPage = ({ data }: { data: WorldEditPageData }) => {
                                         'http://dev.bukkit.org/bukkit-plugins/worldedit/files/'
                                     }
                                 >
-                                    Latest release for Bukkit
+                                    Stable builds for Bukkit
                                 </BlueOutboundButton>
                             </p>
                             <p>
@@ -262,7 +262,7 @@ const WorldEditPage = ({ data }: { data: WorldEditPageData }) => {
                                         'https://minecraft.curseforge.com/projects/worldedit'
                                     }
                                 >
-                                    Latest release for Forge
+                                    Stable builds for Forge
                                 </BlueOutboundButton>
                             </p>
                             <p>
@@ -306,7 +306,7 @@ const WorldEditPage = ({ data }: { data: WorldEditPageData }) => {
                                         'https://minecraft.curseforge.com/projects/worldedit'
                                     }
                                 >
-                                    Latest release for Fabric
+                                    Stable builds for Fabric
                                 </BlueOutboundButton>
                             </p>
                             <p>
@@ -350,7 +350,7 @@ const WorldEditPage = ({ data }: { data: WorldEditPageData }) => {
                                         'https://ore.spongepowered.org/enginehub/WorldEdit'
                                     }
                                 >
-                                    Latest release for Sponge
+                                    Stable builds for Sponge
                                 </BlueOutboundButton>
                             </p>
                             <p>

--- a/main-site/src/pages/worldguard.tsx
+++ b/main-site/src/pages/worldguard.tsx
@@ -197,7 +197,7 @@ const WorldGuardPage = ({ data }: { data: WorldGuardPageData }) => {
                                         'http://dev.bukkit.org/bukkit-plugins/worldguard/files/'
                                     }
                                 >
-                                    Latest release for Bukkit
+                                    Stable builds for Bukkit
                                 </BlueOutboundButton>
                             </p>
                             <p>


### PR DESCRIPTION
This allows people looking for older releases to properly understand where these pages link to.