### PR TITLE
perf(paste): improve performance of paste and profile rendering

### DIFF
--- a/paste/pages/[id]/index.tsx
+++ b/paste/pages/[id]/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { Layout } from '@paste/Layout';
 import { NextPageContext } from 'next';
 import Router from 'next/router';
-import axios from 'axios';
 import PasteComponent from '@paste/views/PasteComponent';
 import ProfileComponent from '@paste/views/ProfileComponent';
 import ReportComponent from '@paste/views/ReportComponent';
+import { loadPaste } from '@paste/loadPaste';
 
 interface DocumentProps extends PasteProps {
     extension: Extension;
@@ -38,7 +38,7 @@ function isValidExtension(extension: string): extension is Extension {
     return EXTENSIONS.has(extension);
 }
 
-Document.getInitialProps = async ({ query, res }: NextPageContext) => {
+export const getServerSideProps = async ({ query, res }: NextPageContext) => {
     const { id } = query;
     let pasteId = `${id}`;
     let extension: Extension = '';
@@ -59,9 +59,7 @@ Document.getInitialProps = async ({ query, res }: NextPageContext) => {
             }
         }
     }
-    const pasteContents = (await axios.get(
-        `https://paste.enginehub.org/documents/${pasteId}`
-    )).data;
+    const pasteContents = await loadPaste(pasteId);
     if (!pasteContents) {
         if (res) {
             res.writeHead(302, {
@@ -73,8 +71,10 @@ Document.getInitialProps = async ({ query, res }: NextPageContext) => {
         }
     }
     return {
-        paste: pasteContents || '',
-        extension
+        props: {
+            paste: pasteContents || '',
+            extension
+        }
     };
 };
 

--- a/paste/src/views/ProfileComponent.tsx
+++ b/paste/src/views/ProfileComponent.tsx
@@ -103,7 +103,7 @@ function parseLine(line: string): { name: string; selfTime: number } {
 }
 
 const ProfileNode: React.FC<ProfileNodeProps> = ({ entry, allTime }) => {
-    const [open, setOpen] = useState<boolean>(true);
+    const [open, setOpen] = useState<boolean>(false);
     const onToggle = () => setOpen(!open);
     const percent = calculatePercentage(entry.selfTime, allTime);
     return (


### PR DESCRIPTION
I was often seeing timeout errors when rendering profile pastes. This closes profile nodes by default, preventing long render times.

On top of that, this also uses NextJS 9.3's getServerSideProps rather than getInitialProps, removing the need for the intermediary HTTP request, further increasing performance across the board.