### PR TITLE
Show branch warning on all non-main branches.

### DIFF
--- a/builds/pages/job/[project]/index.tsx
+++ b/builds/pages/job/[project]/index.tsx
@@ -102,8 +102,7 @@ function Index({
                 </BranchButtonList>
             </PageHeader>
             <Container>
-                {activeBranch !== project.defaultBranch &&
-                    !project.pinnedBranches?.includes(activeBranch) && (
+                {activeBranch !== project.defaultBranch && (
                         <BranchWarning
                             currentBranch={activeBranch}
                             mainBranch={project.defaultBranch}


### PR DESCRIPTION
Pinned branch should not imply main branch.